### PR TITLE
front-end fitness param to registration, display/edit on Settings

### DIFF
--- a/app/src/RegistrationForm.js
+++ b/app/src/RegistrationForm.js
@@ -18,6 +18,9 @@ const RegistrationForm = () => {
     confirmPassword: '',
     securityQuestion: '',
     securityAnswer: '',
+    fitnessLevel: '',
+    workoutDuration: '', 
+    focusArea: '' 
   });
 
   const [errors, setErrors] = useState({});
@@ -153,6 +156,47 @@ const RegistrationForm = () => {
             type="text"
             name="securityAnswer"
             value={formData.securityAnswer}
+            onChange={handleChange}
+            required
+          />
+        </div>
+
+
+        <div className="form-group">
+          <label>Current Fitness Level:</label>
+          <select
+            name="fitnessLevel"
+            value={formData.fitnessLevel}
+            onChange={handleChange}
+            required
+          >
+            <option value="">Select your fitness level...</option>
+            <option value="beginner">Beginner</option>
+            <option value="intermediate">Intermediate</option>
+          </select>
+        </div>
+
+        <div className="form-group">
+          <label>Focus Area:</label>
+          <select
+            name="focusArea"
+            value={formData.focusArea}
+            onChange={handleChange}
+            required
+          >
+            <option value="">Select a focus area...</option>
+            <option value="upper_body">Upper Body</option>
+            <option value="lower_body">Lower Body</option>
+            <option value="full_body">Full Body</option>
+          </select>
+        </div>
+
+        <div className="form-group">
+          <label>Workout Duration (minutes):</label>
+          <input
+            type="text"
+            name="workoutTime"
+            value={formData.workoutTime}
             onChange={handleChange}
             required
           />

--- a/app/src/RegistrationForm.js
+++ b/app/src/RegistrationForm.js
@@ -185,9 +185,22 @@ const RegistrationForm = () => {
             required
           >
             <option value="">Select a focus area...</option>
-            <option value="upper_body">Upper Body</option>
-            <option value="lower_body">Lower Body</option>
-            <option value="full_body">Full Body</option>
+            <option value="full body">Full Body</option>
+            <option value="abductors">Abductors</option>
+            <option value="adductors">Adductors</option>
+            <option value="biceps">Biceps</option>
+            <option value="calves">Calves</option>
+            <option value="chest">Chest</option>
+            <option value="core">Core</option>
+            <option value="glutes">Glutes</option>
+            <option value="hamstrings">Hamstrings</option>
+            <option value="lats">Lats</option>
+            <option value="lower back">Lower Back</option>
+            <option value="middle back">Middle Back</option>
+            <option value="neck">Neck</option>
+            <option value="quadriceps">Quadriceps</option>
+            <option value="shoulders">Shoulders</option>
+            <option value="triceps">Triceps</option>
           </select>
         </div>
 

--- a/app/src/Settings.css
+++ b/app/src/Settings.css
@@ -1,19 +1,24 @@
-/* Settings.css */
-
-.landing-page {
-  padding: 0px;
-  text-align: center;
+.setting-item {
+  margin: 20px;
+  cursor: pointer;
 }
-  
-  .settings-content {
-    padding: 40px;
-    text-align: center;
-    color: rgb(6, 6, 6);
-  }
-  
-  @media (max-width: 768px) {
-    .settings-content {
-      padding: 20px;
-    }
-  }
-  
+
+.setting-item p, .setting-item select, .setting-item input {
+  padding: 10px;
+  margin: 5px 0;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background-color: white;
+  box-sizing: border-box;
+  color: #333;
+}
+
+.setting-item select, .setting-item input {
+  cursor: text;
+}
+
+/* Adjust styles for edit mode */
+.setting-item select:focus, .setting-item input:focus {
+  outline: none;
+  border-color: #353535;
+}

--- a/app/src/Settings.js
+++ b/app/src/Settings.js
@@ -68,9 +68,22 @@ const Settings = () => {
               onBlur={handleBlur}
               autoFocus
             >
-              <option value="upper_body">Upper Body</option>
-              <option value="lower_body">Lower Body</option>
-              <option value="full_body">Full Body</option>
+              <option value="full body">Full Body</option>
+              <option value="abductors">Abductors</option>
+              <option value="adductors">Adductors</option>
+              <option value="biceps">Biceps</option>
+              <option value="calves">Calves</option>
+              <option value="chest">Chest</option>
+              <option value="core">Core</option>
+              <option value="glutes">Glutes</option>
+              <option value="hamstrings">Hamstrings</option>
+              <option value="lats">Lats</option>
+              <option value="lower back">Lower Back</option>
+              <option value="middle back">Middle Back</option>
+              <option value="neck">Neck</option>
+              <option value="quadriceps">Quadriceps</option>
+              <option value="shoulders">Shoulders</option>
+              <option value="triceps">Triceps</option>
             </select>
           ) : (
             <p onClick={() => toggleEdit('focusArea')}>{userSettings.focusArea}</p>

--- a/app/src/Settings.js
+++ b/app/src/Settings.js
@@ -1,17 +1,99 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Navbar from './Navbar';
 import './Settings.css';
 
 const Settings = () => {
+  // States to manage display and edit modes
+  const [editMode, setEditMode] = useState({
+    fitnessLevel: false,
+    focusArea: false,
+    workoutTime: false
+  });
+
+  // Placeholder state for user settings
+  const [userSettings, setUserSettings] = useState({
+    fitnessLevel: '(current fitness level)',
+    focusArea: '(current focus area)',
+    workoutTime: '(current workout duration)'
+  });
+
+  // Handle edit mode toggle
+  const toggleEdit = (field) => {
+    setEditMode({ ...editMode, [field]: !editMode[field] });
+  };
+
+  // Handle changes in the edit form and exit edit mode
+  const handleChange = (e) => {
+    setUserSettings({ ...userSettings, [e.target.name]: e.target.value });
+    toggleEdit(e.target.name);
+  };
+
+  // Handle exiting edit mode when clicking outside
+  const handleBlur = (e) => {
+    toggleEdit(e.target.name);
+  };
+
   return (
     <div className="landing-page">
       <Navbar />
 
       <section className="settings-content">
-        <h2>This area is undeveloped</h2>
-        <p>Later, you'll be able to adjust your preferences and account settings here.</p>
-      </section>
+        <h2>Fitness Settings</h2>
 
+        {/* Fitness Level */}
+        <div className="setting-item">
+          {editMode.fitnessLevel ? (
+            <select
+              name="fitnessLevel"
+              value={userSettings.fitnessLevel}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              autoFocus
+            >
+              <option value="beginner">Beginner</option>
+              <option value="intermediate">Intermediate</option>
+            </select>
+          ) : (
+            <p onClick={() => toggleEdit('fitnessLevel')}>{userSettings.fitnessLevel}</p>
+          )}
+        </div>
+
+        {/* Focus Area */}
+        <div className="setting-item">
+          {editMode.focusArea ? (
+            <select
+              name="focusArea"
+              value={userSettings.focusArea}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              autoFocus
+            >
+              <option value="upper_body">Upper Body</option>
+              <option value="lower_body">Lower Body</option>
+              <option value="full_body">Full Body</option>
+            </select>
+          ) : (
+            <p onClick={() => toggleEdit('focusArea')}>{userSettings.focusArea}</p>
+          )}
+        </div>
+
+        {/* Workout Time */}
+        <div className="setting-item">
+          {editMode.workoutTime ? (
+            <input
+              type="text"
+              name="workoutTime"
+              value={userSettings.workoutTime}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              autoFocus
+            />
+          ) : (
+            <p onClick={() => toggleEdit('workoutTime')}>{userSettings.workoutTime}</p>
+          )}
+        </div>
+
+      </section>
     </div>
   );
 };


### PR DESCRIPTION
Added front end functionality to registration form for fitness params. Can update to pull actual options from csv columns. 
// TODO: save params to user table to be used by routine generator.

Set up basic Settings page. Will display the params from the user table. Clicking on a param allows for editing/updating in page.
// TODO: link these to user table

![UpdatedRegistration](https://github.com/ernestorendon/InfiniFit/assets/100811655/518aa560-407c-4822-a68c-e9aceaf2a694)
![display](https://github.com/ernestorendon/InfiniFit/assets/100811655/e26d1bce-5646-4160-82c7-210f1529a775)
![edit_in-page](https://github.com/ernestorendon/InfiniFit/assets/100811655/fde08ce4-4b98-46f0-93e3-ab58c8203e6d)
